### PR TITLE
`TestCase::tearDown()` method no longer empties temporary files. This…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 2.x branch
 ## 2.18 branch
 ### 2.18.7
+* `TestCase::tearDown()` method no longer empties temporary files. This should
+    be done as appropriate;
 * `Plugin::path()` takes only a string or `null` as first argument, and no more
     arrays. It always returns a string and if you ask for the path of a file
     that does not exist, it throws an exception;

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -49,8 +49,6 @@ abstract class TestCase extends CakeTestCase
     {
         parent::tearDown();
 
-        @unlink_recursive(TMP);
-
         if (LOGS !== TMP) {
             @unlink_recursive(LOGS, 'empty');
         }


### PR DESCRIPTION
… should

    be done as appropriate